### PR TITLE
main: add reload, read and wirte commands in serial console for basic memory debug

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ embedded-time = "0.12.1"
 embedded-cli = "0.2.1"
 embedded-io = "0.6.1"
 embedded-hal = "1.0.0"
+heapless = "0.8.0"
 
 [[bin]]
 name = "bouffaloader"


### PR DESCRIPTION
- reload: scan TF card and reload device tree and zImage kernel.
- read `<address>`: read data from a specified address.
- write `<address>` `<value>`: write a value to a specified address.

### example
```bash
$ reload
$ load from sdcard success
$ read 0x3000F100
$ Read value from 0x3000f100: 0x80080000
$ write 0x3000F100 0x802b0200
$ read 0x3000F100
$ Read value from 0x3000f100:0x802b0200
```

### test example  on M1s dock board
![1732535434525-2024-11-25-19:50:34.png](https://fastly.jsdelivr.net/gh/ZhengLongBing/images@main/pictures/1732535434525-2024-11-25-19:50:34.png)