### PR TITLE
build: add target configuration of "riscv64imac-unknown-none-elf"

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,2 @@
+[build]
+target = "riscv64imac-unknown-none-elf"


### PR DESCRIPTION
- This addition facilitates better integration and usage with IDEs like VSCode and RustRover.