### PR TITLE
main: add print command in cli for boot debug

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -148,6 +148,8 @@ fn run_cli<W: Write, R: Read, L: OutputPin, SPI, PADS, const I: usize>(
             #[command(subcommand)]
             command: Option<BootargsCommand<'a>>,
         },
+        ///print the infomation in configs.bootargs
+        Print, 
     }
 
     #[derive(Command)]
@@ -251,6 +253,10 @@ fn run_cli<W: Write, R: Read, L: OutputPin, SPI, PADS, const I: usize>(
                     },
                     Base::Boot => {
                         run_payload();
+                    }
+                    Base::Print => {
+                        // Print the information about the configs.bootargs variable
+                        writeln!(d.tx, "configs.bootargs = {:?}", _c.bootargs).ok();
                     }
                 }
                 Ok(())


### PR DESCRIPTION
This PR implements the print command, which has been tested and works fine.

`print：`Print the information about the configs.bootargs variable

the test result are as follows：
![L X(`_DM}CM3_0%{)9HI8L4](https://github.com/user-attachments/assets/736152eb-cbe4-43e1-8e23-2f1861adc645)
