### PR TITLE
refactor: split code into modular structure for better organization

### DIFF
--- a/src/device.rs
+++ b/src/device.rs
@@ -1,0 +1,32 @@
+use bouffalo_hal::spi::Spi;
+use embedded_hal::digital::OutputPin;
+use embedded_io::{Read, Write};
+
+/// Device structure containing all hardware interfaces
+pub struct Device<
+    W: Write,
+    R: Read,
+    L: OutputPin,
+    SPI: core::ops::Deref<Target = bouffalo_hal::spi::RegisterBlock>,
+    PADS,
+    const I: usize,
+> {
+    pub tx: W,
+    pub rx: R,
+    pub led: L,
+    pub spi: Spi<SPI, PADS, I>,
+}
+
+/// Configuration structure for storing system settings
+pub struct Config {
+    pub bootargs: heapless::String<128>,
+}
+
+impl Config {
+    /// Creates a new Config instance with default values
+    pub fn new() -> Self {
+        Self {
+            bootargs: heapless::String::new(),
+        }
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,10 @@
 #![no_std]
 #![no_main]
 
+mod device;
+mod sdcard;
+mod utils;
+
 use bouffalo_hal::{prelude::*, psram::init_psram, spi::Spi, uart::Config as UartConfig};
 use bouffalo_rt::{entry, Clocks, Peripherals};
 use core::ptr;
@@ -8,35 +12,11 @@ use core::{fmt::Write as _, str::FromStr};
 use embedded_cli::{cli::CliBuilder, Command};
 use embedded_hal::{digital::OutputPin, spi::MODE_3};
 use embedded_io::{Read, Write};
-use embedded_sdmmc::{Mode, SdCard, VolumeManager};
 use embedded_time::rate::*;
 use panic_halt as _;
+use utils::{format_hex, parse_hex, read_memory, write_memory};
 
-struct MyTimeSource {}
-
-impl embedded_sdmmc::TimeSource for MyTimeSource {
-    fn get_timestamp(&self) -> embedded_sdmmc::Timestamp {
-        embedded_sdmmc::Timestamp::from_calendar(2023, 1, 1, 0, 0, 0).unwrap()
-    }
-}
-
-struct Device<
-    W: Write,
-    R: Read,
-    L: OutputPin,
-    SPI: core::ops::Deref<Target = bouffalo_hal::spi::RegisterBlock>,
-    PADS,
-    const I: usize,
-> {
-    tx: W,
-    rx: R,
-    led: L,
-    spi: Spi<SPI, PADS, I>,
-}
-
-struct Config {
-    bootargs: heapless::String<128>,
-}
+use crate::device::{Config, Device};
 
 #[entry]
 fn main(p: Peripherals, c: Clocks) -> ! {
@@ -66,9 +46,9 @@ fn main(p: Peripherals, c: Clocks) -> ! {
         )
     };
     let mut d = Device { tx, rx, led, spi };
+    let mut config = Config::new();
 
-    // Display bouffaloader banner.
-    // TODO
+    // Display welcome message.
     writeln!(d.tx, "Welcome to bouffaloader🦀!").ok();
 
     // Initialize PSRAM.
@@ -76,152 +56,23 @@ fn main(p: Peripherals, c: Clocks) -> ! {
     writeln!(d.tx, "PSRAM initialization success").ok();
 
     // Initialize sdcard and load files.
-    let mut config = Config {
-        bootargs: heapless::String::new(),
-    };
-    if load_from_sdcard(&mut d, &mut config).is_err() {
+    if sdcard::load_from_sdcard(&mut d, &mut config).is_err() {
         writeln!(d.tx, "Load from sdcard fail").ok();
         run_cli(&mut d, &mut config);
     }
 
-    // Skip run_payload if both buttons are pressed.
+    // Check button states for CLI mode.
     let mut button_1 = p.gpio.io22.into_pull_up_input();
     let mut button_2 = p.gpio.io23.into_pull_up_input();
-    let button_1_pressed = button_1.is_low().unwrap();
-    let button_2_pressed = button_2.is_low().unwrap();
-    if button_1_pressed && button_2_pressed {
+    if button_1.is_low().unwrap() && button_2.is_low().unwrap() {
         run_cli(&mut d, &mut config);
-    };
+    }
 
     // Run payload.
     run_payload();
 }
 
-fn load_from_sdcard<
-    W: Write,
-    R: Read,
-    L: OutputPin,
-    SPI: core::ops::Deref<Target = bouffalo_hal::spi::RegisterBlock>,
-    PADS,
-    const I: usize,
->(
-    d: &mut Device<W, R, L, SPI, PADS, I>,
-    c: &mut Config,
-) -> Result<(), ()> {
-    // TODO: return error message
-    let delay = riscv::delay::McycleDelay::new(40_000_000);
-    let sdcard = SdCard::new(&mut d.spi, delay);
-
-    // Initialize sdcard.
-    writeln!(d.tx, "initializing sdcard...").ok();
-    const MAX_RETRY_TIME: usize = 3;
-    let mut retry_time = 0;
-    while sdcard.get_card_type().is_none() {
-        retry_time = retry_time + 1;
-        if retry_time == MAX_RETRY_TIME {
-            writeln!(d.tx, "error: failed to initialize sdcard.").ok();
-            return Err(());
-        }
-    }
-
-    // Display sdcard information.
-    writeln!(
-        d.tx,
-        "sdcard initialized success: size = {:.2} GB",
-        sdcard.num_bytes().unwrap() as f32 / (1024.0 * 1024.0 * 1024.0)
-    )
-    .ok();
-
-    // Initialize filesystem.
-    let mut volume_mgr = VolumeManager::new(sdcard, MyTimeSource {});
-    let volume0 = volume_mgr
-        .open_raw_volume(embedded_sdmmc::VolumeIdx(0))
-        .map_err(|_| ())?;
-    let root_dir = volume_mgr.open_root_dir(volume0).map_err(|_| ())?;
-    writeln!(d.tx, "filesystem initialized success.").ok();
-
-    // Read configuration from `config.toml`.
-    // TODO: Use toml crate to parse config file in later versions.
-    let bl808_cfg = "CONFIG~1.TOM";
-    let buffer = &mut [0u8; 128];
-    if load_file_into_memory(
-        &mut volume_mgr,
-        root_dir,
-        bl808_cfg,
-        buffer.as_mut_ptr() as usize,
-        128,
-    )
-    .is_err()
-    {
-        writeln!(d.tx, "error: cannot load config file `config.toml`.").ok();
-        return Err(());
-    }
-    let config_str = core::str::from_utf8(buffer).map_err(|_| ())?;
-    let start_pos = config_str.find("bootargs = ").ok_or(())?;
-    c.bootargs = heapless::String::from_str(&config_str[start_pos + 11..config_str.len()])
-        .map_err(|_| ())?;
-    writeln!(d.tx, "read config success: bootargs = {}", c.bootargs,).ok();
-
-    // Load `bl808.dtb` to memory.
-    let bl808_dtb = "BL808.DTB";
-    let dtb_addr = 0x51ff_8000;
-    let res = load_file_into_memory(&mut volume_mgr, root_dir, bl808_dtb, dtb_addr, 64 * 1024);
-    if res.is_err() {
-        writeln!(d.tx, "error: cannot load dtb file `bl808.dtb`.").ok();
-        return Err(());
-    }
-    writeln!(d.tx, "load dtb file success, size = {} bytes", res.unwrap()).ok();
-
-    // Load `zImage` to memory.
-    let bl808_z_img = "ZIMAGE";
-    let z_image_addr = 0x5000_0000;
-    let res = load_file_into_memory(
-        &mut volume_mgr,
-        root_dir,
-        bl808_z_img,
-        z_image_addr,
-        32 * 1024 * 1024,
-    );
-    if res.is_err() {
-        writeln!(d.tx, "error: cannot load zImage file `zImage`.").ok();
-        return Err(());
-    }
-    writeln!(
-        d.tx,
-        "load zImage file success, size = {} bytes",
-        res.unwrap()
-    )
-    .ok();
-
-    volume_mgr.close_dir(root_dir).unwrap();
-    writeln!(d.tx, "load files from sdcard success.").ok();
-    Ok(())
-}
-
-fn load_file_into_memory<T: embedded_sdmmc::BlockDevice>(
-    volume_mgr: &mut VolumeManager<T, MyTimeSource>,
-    dir: embedded_sdmmc::RawDirectory,
-    file_name: &str,
-    addr: usize,
-    max_size: u32,
-) -> Result<usize, ()> {
-    // TODO: return error message
-    volume_mgr
-        .find_directory_entry(dir, file_name)
-        .map_err(|_| ())?;
-    let file = volume_mgr
-        .open_file_in_dir(dir, file_name, Mode::ReadOnly)
-        .map_err(|_| ())?;
-    let file_size = volume_mgr.file_length(file).map_err(|_| ())?;
-    if file_size > max_size {
-        return Err(());
-    }
-    let target = unsafe { core::slice::from_raw_parts_mut(addr as *mut u8, file_size as usize) };
-    let size = volume_mgr.read(file, target).map_err(|_| ())?;
-    volume_mgr.close_file(file).ok();
-    Ok(size)
-}
-
+/// Executes the loaded payload
 fn run_payload() -> ! {
     const ZIMAGE_ADDRESS: usize = 0x5000_0000; // Load address of Linux zImage
     const DTB_ADDRESS: usize = 0x51FF_8000; // Address of the device tree blob
@@ -237,6 +88,7 @@ fn run_payload() -> ! {
     loop {}
 }
 
+/// Runs the Command Line Interface
 fn run_cli<
     W: Write,
     R: Read,
@@ -332,7 +184,7 @@ fn run_cli<
                         },
                     },
                     Base::Reload => {
-                        let _ = load_from_sdcard(d, c);
+                        let _ = sdcard::load_from_sdcard(d, c);
                     }
                     Base::Read { addr } => match parse_hex(addr) {
                         Some(a) => {
@@ -383,54 +235,4 @@ fn run_cli<
             }),
         );
     }
-}
-
-/// Convert a 32-bit unsigned integer to a hexadecimal string,
-/// The string starts with "0x", and the `uppercase` parameter determines whether the letters are uppercase.
-pub fn format_hex(num: u32, uppercase: bool) -> heapless::String<10> {
-    let mut buf = heapless::String::<10>::new();
-    let _ = buf.push_str("0x");
-    for i in (0..8).rev() {
-        let digit = (num >> (i * 4)) & 0xF;
-        let c = match digit {
-            0x0..=0x9 => (b'0' + digit as u8) as char,
-            0xA..=0xF => {
-                if uppercase {
-                    (b'A' + (digit as u8 - 10)) as char
-                } else {
-                    (b'a' + (digit as u8 - 10)) as char
-                }
-            }
-            _ => unreachable!(),
-        };
-        let _ = buf.push(c);
-    }
-
-    buf
-}
-
-/// Parses a hexadecimal string in the format "0xXXXXXXXX" and converts it to a 32-bit unsigned integer.
-pub fn parse_hex(hex_str: &str) -> Option<u32> {
-    if !hex_str.starts_with("0x") || hex_str.len() != 10 {
-        return None;
-    }
-    let mut result = 0u32;
-    for c in hex_str[2..].chars() {
-        let digit = c.to_digit(16)?;
-        result = result << 4 | digit;
-    }
-
-    Some(result)
-}
-
-/// Reads a 32-bit unsigned integer from the specified memory address using a volatile operation.
-#[inline]
-pub(crate) fn read_memory(addr: u32) -> u32 {
-    unsafe { ptr::read_volatile(addr as *const u32) }
-}
-
-/// Writes a 32-bit unsigned integer value to the specified memory address using a volatile operation.
-#[inline]
-pub(crate) fn write_memory(addr: u32, val: u32) {
-    unsafe { ptr::write_volatile(addr as *mut u32, val) }
 }

--- a/src/sdcard.rs
+++ b/src/sdcard.rs
@@ -1,0 +1,141 @@
+use core::str::FromStr;
+
+use crate::device::{Config, Device};
+use embedded_hal::digital::OutputPin;
+use embedded_io::{Read, Write};
+use embedded_sdmmc::{Mode, SdCard, TimeSource, Timestamp, VolumeManager};
+use riscv::delay::McycleDelay;
+
+/// Time source implementation for SD card filesystem
+pub struct MyTimeSource {}
+
+impl TimeSource for MyTimeSource {
+    fn get_timestamp(&self) -> Timestamp {
+        // Returns a fixed timestamp for simplicity
+        Timestamp::from_calendar(2023, 1, 1, 0, 0, 0).unwrap()
+    }
+}
+
+/// Loads necessary files from SD card into memory
+pub fn load_from_sdcard<
+    W: Write,
+    R: Read,
+    L: OutputPin,
+    SPI: core::ops::Deref<Target = bouffalo_hal::spi::RegisterBlock>,
+    PADS,
+    const I: usize,
+>(
+    d: &mut Device<W, R, L, SPI, PADS, I>,
+    c: &mut Config,
+) -> Result<(), ()> {
+    // SD card initialization
+    let sdcard = SdCard::new(&mut d.spi, McycleDelay::new(40_000_000));
+    writeln!(d.tx, "initializing sdcard...").ok();
+    const MAX_RETRY_TIME: usize = 3;
+    let mut retry_time = 0;
+    while sdcard.get_card_type().is_none() {
+        retry_time += 1;
+        if retry_time == MAX_RETRY_TIME {
+            writeln!(d.tx, "error: failed to initialize sdcard.").ok();
+            return Err(());
+        }
+    }
+
+    // Display SD card information
+    writeln!(
+        d.tx,
+        "sdcard initialized success: size = {:.2} GB",
+        sdcard.num_bytes().unwrap() as f32 / (1024.0 * 1024.0 * 1024.0)
+    )
+    .ok();
+
+    // Initialize filesystem and open root directory
+    let mut volume_mgr = VolumeManager::new(sdcard, MyTimeSource {});
+    let volume0 = volume_mgr
+        .open_raw_volume(embedded_sdmmc::VolumeIdx(0))
+        .map_err(|_| ())?;
+    let root_dir = volume_mgr.open_root_dir(volume0).map_err(|_| ())?;
+
+    // Read configuration from `config.toml`.
+    // TODO: Use toml crate to parse config file in later versions.
+    let bl808_cfg = "CONFIG~1.TOM";
+    let buffer = &mut [0u8; 128];
+    if load_file_into_memory(
+        &mut volume_mgr,
+        root_dir,
+        bl808_cfg,
+        buffer.as_mut_ptr() as usize,
+        128,
+    )
+    .is_err()
+    {
+        writeln!(d.tx, "error: cannot load config file `config.toml`.").ok();
+        return Err(());
+    }
+
+    // Parse configuration
+    if let Ok(config_str) = core::str::from_utf8(buffer) {
+        if let Some(start_pos) = config_str.find("bootargs = ") {
+            c.bootargs =
+                heapless::String::from_str(&config_str[start_pos + 11..]).map_err(|_| ())?;
+            writeln!(d.tx, "read config success: bootargs = {}", c.bootargs).ok();
+        } else {
+            writeln!(d.tx, "error: invalid config format.").ok();
+            return Err(());
+        }
+    } else {
+        writeln!(d.tx, "error: invalid config encoding.").ok();
+        return Err(());
+    }
+
+    // Load `bl808.dtb` and `zImage`
+    for (filename, addr, size) in [
+        ("BL808.DTB", 0x51ff_8000, 64 * 1024),
+        ("ZIMAGE", 0x5000_0000, 32 * 1024 * 1024),
+    ] {
+        match load_file_into_memory(&mut volume_mgr, root_dir, filename, addr, size) {
+            Ok(bytes) => {
+                writeln!(d.tx, "load {} success, size = {} bytes", filename, bytes).ok();
+            }
+            Err(_) => {
+                writeln!(d.tx, "error: cannot load file `{}`.", filename).ok();
+                return Err(());
+            }
+        }
+    }
+
+    volume_mgr.close_dir(root_dir).unwrap();
+    writeln!(d.tx, "load files from sdcard success.").ok();
+    Ok(())
+}
+
+/// Loads a file from SD card into specified memory address
+pub fn load_file_into_memory<T: embedded_sdmmc::BlockDevice>(
+    volume_mgr: &mut VolumeManager<T, MyTimeSource>,
+    dir: embedded_sdmmc::RawDirectory,
+    file_name: &str,
+    addr: usize,
+    max_size: u32,
+) -> Result<usize, ()> {
+    // Find and open the file
+    volume_mgr
+        .find_directory_entry(dir, file_name)
+        .map_err(|_| ())?;
+
+    let file = volume_mgr
+        .open_file_in_dir(dir, file_name, Mode::ReadOnly)
+        .map_err(|_| ())?;
+
+    // Check file size
+    let file_size = volume_mgr.file_length(file).map_err(|_| ())?;
+    if file_size > max_size {
+        return Err(());
+    }
+
+    // Read file content into memory
+    let target = unsafe { core::slice::from_raw_parts_mut(addr as *mut u8, file_size as usize) };
+    let size = volume_mgr.read(file, target).map_err(|_| ())?;
+    volume_mgr.close_file(file).ok();
+
+    Ok(size)
+}

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,0 +1,52 @@
+use core::ptr;
+
+/// Converts a 32-bit unsigned integer to a hexadecimal string
+pub fn format_hex(num: u32, uppercase: bool) -> heapless::String<10> {
+    let mut buf = heapless::String::<10>::new();
+    let _ = buf.push_str("0x");
+
+    for i in (0..8).rev() {
+        let digit = (num >> (i * 4)) & 0xF;
+        let c = match digit {
+            0x0..=0x9 => (b'0' + digit as u8) as char,
+            0xA..=0xF => {
+                if uppercase {
+                    (b'A' + (digit as u8 - 10)) as char
+                } else {
+                    (b'a' + (digit as u8 - 10)) as char
+                }
+            }
+            _ => unreachable!(),
+        };
+        let _ = buf.push(c);
+    }
+
+    buf
+}
+
+/// Parses a hexadecimal string into a 32-bit unsigned integer
+pub fn parse_hex(hex_str: &str) -> Option<u32> {
+    if !hex_str.starts_with("0x") || hex_str.len() != 10 {
+        return None;
+    }
+
+    let mut result = 0u32;
+    for c in hex_str[2..].chars() {
+        let digit = c.to_digit(16)?;
+        result = result << 4 | digit;
+    }
+
+    Some(result)
+}
+
+/// Reads a 32-bit unsigned integer from the specified memory address
+#[inline]
+pub fn read_memory(addr: u32) -> u32 {
+    unsafe { ptr::read_volatile(addr as *const u32) }
+}
+
+/// Writes a 32-bit unsigned integer to the specified memory address
+#[inline]
+pub fn write_memory(addr: u32, val: u32) {
+    unsafe { ptr::write_volatile(addr as *mut u32, val) }
+}


### PR DESCRIPTION
In this pull reques, we reorganized the codebase into separate modules to improve maintainability and readability:
- `device`: Contains device-related structs and implementations
- `sdcard`: Handles SD card operations and file system management
- `utils`: Houses utility functions for hex formatting and memory operations
- `main`: Maintains core program flow and initialization

Tested on my m1s dock development board: 
![image](https://github.com/user-attachments/assets/172b1a62-01c6-4fc5-b572-7d148c66d9d4)
